### PR TITLE
Add count and get methods to FileStorage and DBStorage classes

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -8,7 +8,7 @@ from os import getenv
 
 # set the default name for the file storage, the name changes with the
 # environment.
-if any('unittest' in arg for arg in sys.argv):
+if any('unittest' in arg for arg in sys.argv) or getenv('HBNB_ENV'):
     FILE_PATH = 'dummy_test_file.json'
 else:
     FILE_PATH = "file.json"

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -71,3 +71,33 @@ class FileStorage:
     def close(self):
         """call reload() method for deserializing the JSON file to objects"""
         self.reload()
+
+    def count(self, cls=None) -> int:
+        """
+        Returns the number of objects in the storage.
+
+        Args:
+            cls (optional): The class name of the objects to count.
+            If not provided, counts all objects.
+
+        Returns:
+            int: The number of objects in the storage.
+        """
+        return len(self.all(cls))
+
+    def get(self, cls=None, cls_id=None) -> object:
+        """
+        Returns the instance object that has the specified class name and id.
+
+        Args:
+            cls (optional): The class name of the object to retrieve.
+            cls_id(optional): The ID of the object
+
+        Returns:
+            int: The number of objects in the storage.
+        """
+        if None in [cls, cls_id]:
+            return None
+
+        key = f"{cls.__name__}.{cls_id}"
+        return self.__objects.get(key)

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -3,10 +3,12 @@
 Contains the TestDBStorageDocs and TestDBStorage classes
 """
 
+from os import getenv
 import inspect
 import unittest
 import pep8
 import models
+import models.base_model
 from models.engine import db_storage
 from models.amenity import Amenity
 from models.city import City
@@ -97,3 +99,55 @@ class TestFileStorage(unittest.TestCase):
     @unittest.skipIf(models.storage_t != "db", "not testing db storage")
     def test_save(self):
         """Test that save properly saves objects to file.json"""
+
+
+@unittest.skipUnless(getenv('HBNB_TYPE_STORAGE') == "db", "testing DBStorage")
+class TestDBStorage(unittest.TestCase):
+    """Tests the DBStorage."""
+
+    def setUp(self) -> None:
+        models.storage.drop_all_tables()
+
+    def test_count_when_empty(self):
+        """Test that the `count` method returns zero when nothing exist."""
+        self.assertTrue(models.storage.count() == 0)
+
+    def test_count_all_objects(self):
+        """Test that the `count` method returns the right number of objects."""
+        for i in range(1, 11):
+            state = State(name=f"State_{i}")
+            state.save()
+            City(name=f"City_{i}", state_id=state.id).save()
+
+        self.assertEqual(models.storage.count(), 20)
+
+    def test_count_with_model_name(self):
+        """Test that the `count` method returns the right number of objects for
+        a particular class."""
+        State(name="Arizona").save()
+        State(name="California").save()
+
+        self.assertEqual(models.storage.count(State), 2)
+
+    def test_get_with_non_existent(self):
+        """Test that `get` method returns None for non-existent objects."""
+        self.assertIsNone(models.storage.get(User, 'abcd-1234-test-5678'))
+
+    def test_get_with_class_only(self):
+        """Test that the `get` method operates correctly when only the class
+        argument is passed."""
+        self.assertIsNone(models.storage.get(User))
+
+    def test_get_with_valid_class(self):
+        """Test that `get` method returns the right object."""
+        state = State(name="Greater Accra")
+        state.save()
+
+        # test for state instance
+        self.assertEqual(models.storage.get(
+            State, state.id), state)
+
+        city = City(name="Tema", state_id=state.id)
+        city.save()
+        self.assertEqual(models.storage.get(
+            City, city.id), city)

--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -6,6 +6,7 @@ Contains the TestFileStorageDocs classes
 import inspect
 import json
 import unittest
+from random import choice
 import pep8
 import models
 from models import FILE_PATH
@@ -91,10 +92,13 @@ class TestFileStorageDocs(unittest.TestCase):
             )
 
 
+@unittest.skipIf(models.storage_t == "db", "file storage")
 class TestFileStorage(unittest.TestCase):
     """Test the FileStorage class"""
 
-    @unittest.skipIf(models.storage_t == "db", "not testing file storage")
+    def setUp(self) -> None:
+        lazy_methods.empty_object_dictionary(models.storage.all())
+
     def test_all_returns_dict(self):
         """Test that all returns the FileStorage.__objects attr"""
         storage = FileStorage()
@@ -102,43 +106,75 @@ class TestFileStorage(unittest.TestCase):
         self.assertEqual(type(new_dict), dict)
         self.assertIs(new_dict, storage.all())
 
-    @unittest.skipIf(models.storage_t == "db", "not testing file storage")
     def test_new(self):
         """test that new adds an object to the FileStorage.__objects attr"""
-        storage = FileStorage()
-        objects = storage.all()
-        save = dict(objects)
-
-        lazy_methods.empty_object_dictionary(objects)
         test_dict = {}
 
         for key, value in classes.items():
             with self.subTest(key=key, value=value):
                 instance = value()
                 instance_key = instance.__class__.__name__ + "." + instance.id
-                storage.new(instance)
+                models.storage.new(instance)
                 test_dict[instance_key] = instance
-                self.assertEqual(test_dict, storage.all())
-        objects = save
+                self.assertEqual(test_dict, models.storage.all())
 
-    @unittest.skipIf(models.storage_t == "db", "not testing file storage")
     def test_save(self):
         """Test that save properly saves objects to file.json"""
-        storage = FileStorage()
-        objects = storage.all()
-        lazy_methods.empty_object_dictionary(objects)
         new_dict = {}
 
         for key, value in classes.items():
             instance = value()
             instance_key = instance.__class__.__name__ + "." + instance.id
             new_dict[instance_key] = instance
-            storage.new(instance)
+            models.storage.new(instance)
 
-        storage.save()
+        models.storage.save()
         for key, value in new_dict.items():
             new_dict[key] = value.to_dict()
         string = json.dumps(new_dict)
         with open(FILE_PATH, "r", encoding="utf-8") as f:
             js = f.read()
         self.assertEqual(json.loads(string), json.loads(js))
+
+    def test_count_when_empty(self):
+        """Test that the `count` method returns zero when nothing exist."""
+        self.assertTrue(models.storage.count() == 0)
+
+    def test_count_all_objects(self):
+        """Test that the `count` method returns the right number of objects."""
+        for model in classes.values():
+            models.storage.new(model())
+
+        self.assertEqual(models.storage.count(), len(classes))
+
+    def test_count_with_model_name(self):
+        """Test that the `count` method returns the right number of objects for
+        a particular class."""
+        for key, instance in classes.items():
+            with self.subTest(key=key, model=instance):
+                num_of_instances = choice(range(1, 20))
+                for _ in range(num_of_instances):
+                    instance_obj = instance()
+                    models.storage.new(instance_obj)
+
+                self.assertEqual(models.storage.count(
+                    instance_obj.__class__.__name__), num_of_instances)
+
+    def test_get_with_non_existent(self):
+        """Test that `get` method returns None for non-existent objects."""
+        self.assertIsNone(models.storage.get(User, 'abcd-1234-test-5678'))
+
+    def test_get_with_class_only(self):
+        """Test that the `get` method operates correctly when only the class
+        argument is passed."""
+        self.assertIsNone(models.storage.get(User))
+
+    def test_get_with_valid_class(self):
+        """Test that `get` method returns the right object."""
+        for key, instance in classes.items():
+            with self.subTest(key=key, model=instance):
+                instance_obj = instance()
+                models.storage.new(instance_obj)
+
+                self.assertEqual(models.storage.get(
+                    instance, instance_obj.id), instance_obj)


### PR DESCRIPTION
This pull request adds the count and get methods to the FileStorage and DBStorage classes. The count method returns the number of objects in the storage, while the get method retrieves an instance object based on the specified class name and ID.

Also, respective test cases are added for each method and their storage types.