### PR TITLE
Refactor get method in FileStorage class and add error handling for 404 page not found

### DIFF
--- a/api/v1/app.py
+++ b/api/v1/app.py
@@ -3,7 +3,7 @@
 """This module contains routes for the app."""
 
 import os
-from flask import Flask
+from flask import Flask, jsonify
 from models import storage
 from api.v1.views import app_views
 
@@ -19,9 +19,15 @@ def close(_):
     storage.close()
 
 
+@app.errorhandler(404)
+def page_not_found(_):
+    """Returns an error 404 for page not found errors."""
+    return jsonify({"error": "Not found"}), 404
+
+
 if __name__ == "__main__":
     app.run(
-        host=f"{os.getenv('HBNB_API_HOST', default='0.0.0.0')}",
-        port=f"{os.getenv('HBNB_API_PORT', default='5000')}",
+        host=os.getenv('HBNB_API_HOST', default='0.0.0.0'),
+        port=int(os.getenv('HBNB_API_PORT', default='5000')),
         threaded=True
     )

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -87,17 +87,17 @@ class FileStorage:
 
     def get(self, cls=None, cls_id=None) -> object:
         """
-        Returns the instance object that has the specified class name and id.
+        Retrieve an object from the storage based on the class and ID.
 
         Args:
-            cls (optional): The class name of the object to retrieve.
-            cls_id(optional): The ID of the object
+            cls (type): The class of the object to retrieve.
+            cls_id (str): The ID of the object to retrieve.
 
         Returns:
-            int: The number of objects in the storage.
+            object: The retrieved object, or None if not found.
         """
         if None in [cls, cls_id]:
             return None
 
-        key = f"{cls.__name__}.{cls_id}"
+        key = "{}.{}".format(cls.__name__, cls_id)
         return self.__objects.get(key)


### PR DESCRIPTION
This pull request includes two commits:

1. Refactor get method in FileStorage class to use string formatting for key creation. I did this because I realized the Python version 3.4.3 that the checker is using to check our code doesn't support f-strings which I was using earlier.

2. Refactor app.py to include error handling for 404 page not found.