### PR TITLE
Fix request.get_json() usage and add empty line

### DIFF
--- a/api/v1/views/states.py
+++ b/api/v1/views/states.py
@@ -17,7 +17,7 @@ def handle_states():
         Response: The response object containing the result of the request.
     """
     if request.method == 'POST':
-        data = request.get_json(silent=True)
+        data = request.get_json(force=True, silent=True)
 
         # the data provided must be a dictionary
         if not data or not isinstance(data, dict):
@@ -57,7 +57,7 @@ def handle_state(state_id=None):
         return jsonify({}), 200
 
     if request.method == 'PUT':
-        data = request.get_json(silent=True)
+        data = request.get_json(force=True, silent=True)
 
         # the data provided must be a dictionary
         if not data or not isinstance(data, dict):

--- a/lazy_methods.py
+++ b/lazy_methods.py
@@ -4,6 +4,7 @@
 This module provides methods for various operations.
 """
 
+
 def empty_object_dictionary(objects_dict: dict) -> None:
     """
     Empties the given dictionary by removing all key-value pairs.


### PR DESCRIPTION
This pull request fixes the usage of request.get_json() in states.py to include the 'force' parameter and adds an empty line at the beginning of lazy_methods.py to fix a pep8 error.